### PR TITLE
Implement equals for correct comparison

### DIFF
--- a/maverick-base/src/main/java/com/sshtools/common/files/direct/AbstractDirectFile.java
+++ b/maverick-base/src/main/java/com/sshtools/common/files/direct/AbstractDirectFile.java
@@ -24,6 +24,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Objects;
 
 import com.sshtools.common.files.AbstractFile;
 import com.sshtools.common.files.AbstractFileFactory;
@@ -149,4 +150,18 @@ public abstract class AbstractDirectFile<T extends AbstractDirectFile<T>> extend
 	public void refresh() {
 		
 	}
+	@Override
+	public int hashCode() {
+		return Objects.hash(f, homeDir, hidden);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		AbstractDirectFile that = getClass().cast(o);
+		return Objects.equals(this.f, that.f)
+				&& Objects.equals(this.homeDir, that.homeDir)
+				&& Objects.equals(this.hidden, that.hidden);
+	} 
 }


### PR DESCRIPTION
Needs to have equals implementation in order to compare files correctly when SftpClientTask.putLocalDirectory has the sync partam true. Otherwise the following code will always render true:

f = local.resolveFile(file.getFilename());
if (!op.containsFile(f) && !file.getFilename().equals(".") && !file.getFilename().equals(".."))...