### PR TITLE
Do not recreate the executor on shutdown

### DIFF
--- a/maverick-synergy-common/src/main/java/com/sshtools/synergy/ssh/SshContext.java
+++ b/maverick-synergy-common/src/main/java/com/sshtools/synergy/ssh/SshContext.java
@@ -1297,12 +1297,14 @@ public abstract class SshContext extends ProtocolContext implements
 	}
 
 	public void shutdown() {
-		getExecutorService().shutdown();
-		try {
-			getExecutorService().awaitTermination(30, TimeUnit.SECONDS);
-		} catch (InterruptedException e) {
-		} finally {
-			executor = null;
+		if(executor != null) {
+			executor.shutdown();
+			try {
+				executor.awaitTermination(30, TimeUnit.SECONDS);
+			} catch (InterruptedException e) {
+			} finally {
+				executor = null;
+			}
 		}
 	}
 


### PR DESCRIPTION
If the ssh server is stopped or closed twice, the shutdown can end up
in an infinite loop that overloads the heap. This is due to it
recreating the executor service and adding a new shutdown hook
after the first stop or close set the executor to null. This
commit uses the executor static field value directly in shutdown
instead of getExecutorService to avoid the infinitely recreated
shutdown hooks.

Resolves #24 