### PR TITLE
Fixed division by zero.

### DIFF
--- a/maverick-synergy-client/src/main/java/com/sshtools/client/sftp/SftpChannel.java
+++ b/maverick-synergy-client/src/main/java/com/sshtools/client/sftp/SftpChannel.java
@@ -959,7 +959,7 @@ public class SftpChannel extends AbstractSubsystem {
 				long transferTime = finished - started;
 				long seconds = TimeUnit.MILLISECONDS.toSeconds(transferTime);
 				if(Log.isInfoEnabled()) {
-					Log.info("Optimized write to {} took {} seconds at {}",  filename, seconds, IOUtils.toByteSize(transfered / seconds, 1));
+					Log.info("Optimized write to {} took {} seconds at {}",  filename, seconds, IOUtils.toByteSize(transfered / transferTime * 1000, 1));
 				}
 			}
 


### PR DESCRIPTION
For SFTP file transfers, if data transfer if sub-second duration, Arythmetic exception rised when transfer speed is calculated. 
Reproducable with logging enabled for INFO and below log levels.